### PR TITLE
Add Olelo to Wikis

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,7 @@ Comparison of NoSQL servers: http://kkovacs.eu/cassandra-vs-mongodb-vs-couchdb-v
 * [ikiwiki](http://ikiwiki.info/) - A wiki compiler.
 * [Mediawiki](http://www.mediawiki.org/wiki/MediaWiki) - Used to power Wikipedia.
 * [MoinMoin](http://moinmo.in/) - An advanced, easy to use and extensible WikiEngine with a large community of users.
+ * [Ōlelo Wiki](https://github.com/minad/olelo) - A a wiki that stores pages in a Git repository.
 * [TiddlyWiki](http://tiddlywiki.com) - Complete interactive wiki in JavaScript.
 
 # Resources


### PR DESCRIPTION
Olelo is a wiki that stores pages in a Git repository, supports many markup styles and has an extensible, hackable architecture!

Features:
- Edit, move or delete pages;
- Page attribute editor;
- Support for hierarchical wikis (directory structure);
- File upload;
- History, commit and diff view;
- Locales (Czech, English, French, German);
- Support for many markup languages (Creole, Markdown, Textile, ...);
- RSS/Atom changelog for whole wiki or pages; Section editing for Creole;
- Embedded LaTeX formulas; Syntax highlighting;
- Image resizing, SVG to PNG/JPEG conversion;
- Auto-generated table of contents;
- Previews;
- View pages as S5 presentation;
- Privacy features: Access control lists, Private wiki, Read-only wiki.
