### PR TITLE
Add OpenProject (project collaboration tool).

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ Comparison of NoSQL servers: http://kkovacs.eu/cassandra-vs-mongodb-vs-couchdb-v
 * [ChiliProject](https://www.chiliproject.org) - Fork of Redmine.
 * [GitLab](https://www.gitlab.com/) - Clone of GitHub written in ruby.
 * [Gogs](http://gogs.io/) - Written in Go.
+* [OpenProject](https://www.openproject.org) - Project collaboration with open source.
 * [Redmine](http://www.redmine.org/) - Written in ruby on rails.
 * [The Bug Genie](http://www.thebuggenie.com/) - Written in PHP.
 * [Trac](http://trac.edgewall.org/) - Written in python.


### PR DESCRIPTION
OpenProject is a fork of ChiliProject. Currently, ChiliProject's
development seems stale, but OpenProject is actively developed.
