### PR TITLE
remove Rainloop as it is not open source

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,6 @@ Comparison of NoSQL servers: http://kkovacs.eu/cassandra-vs-mongodb-vs-couchdb-v
 ## Webmails
 *Webmail applications.*
 
-* [RainLoop](http://rainloop.net/) - Simple, modern & fast web-based IMAP client.
 * [Roundcube](http://roundcube.net/) - Browser-based IMAP client with an application-like user interface.
 
 ## Web


### PR DESCRIPTION
Rainloop uses a Creative Commons license with non-commercial clause: http://rainloop.net/licensing/ – unfortunately.

That makes it not open source. The developers don’t seem to plan on changing it, see https://github.com/RainLoop/rainloop-webmail/issues/8
