### PR TITLE
Add NOC Project to Network Configuration Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ A curated list of amazingly awesome open source sysadmin resources inspired by [
 *Network configuration management tools.*
 
 * [GestióIP](http://www.gestioip.net/) - An automated web based IPv4/IPv6 IP Address Management tool.
+* [NOC Project](http://nocproject.org/) - Scalable, high-performance and open-source [OSS](http://en.wikipedia.org/wiki/Operations_support_system) system for ISP, service and content providers.
 * [RANCID](http://www.shrubbery.net/rancid/) - Monitors network device's configurarion and maintain history of changes.
 * [rConfig](http://www.rconfig.com/) - Another network device configuration management tool.
 


### PR DESCRIPTION
Adding [NOC Project](http://nocproject.org/), handy opensource OSS system.