### PR TITLE
Added Seyren to monitoring tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ A curated list of amazingly awesome open source sysadmin resources inspired by [
 * [Riemann](http://riemann.io/) - Flexible and fast events processor allowing complex events/metrics analysis.
 * [Sensu](http://sensuapp.org/) - Open source monitoring framework.
 * [Sentry](https://getsentry.com/) - Application monitoring, event logging and aggregation.
+* [Seyren](https://github.com/scobal/seyren) - An alerting dashboard for Graphite.
 * [Shinken](http://www.shinken-monitoring.org/) - Another monitoring framework.
 * [Thruk](http://www.thruk.org/) - Multibackend monitoring webinterface with support for Naemon, Nagios, Icinga and Shinken.
 * [Xymon](http://www.xymon.com/) - Network monitoring inspired by Big Brother.


### PR DESCRIPTION
https://github.com/scobal/seyren

**Seyren** is an alerting dashboard for *Graphite*.

It's written in Java, and requires an instance of Graphite and MongoDB.

It's licensed under the Apache 2.0 license:

https://github.com/scobal/seyren/blob/master/ASL2.0
