### PR TITLE
Add StackStorm to Cloud Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ A curated list of amazingly awesome open source sysadmin resources inspired by [
 * [Overcast](http://andrewchilds.github.io/overcast/) - Deploy VMs across different cloud providers, and run commands and scripts across any or all of them in parallel via SSH.
 * [Rundeck](http://rundeck.org/) - Simple orchestration tool.
 * [Salt](http://www.saltstack.com/) - It's written in Python.
+* [StackStorm](http://stackstorm.com/) - Event Driven Operations and ChatOps platform for infrastructure management. Written in Python
 
 ## Cloud Storage
 


### PR DESCRIPTION
This pull adds StackStorm (http://www.stackstorm.com) to the list of cloud orchestration tools. This tool ingests events from different tools in an environment and triggers additional actions/workflows based on the user configuration. In addition, actions can be run arbitrary using ChatOps, adding additional context around operations management into the same human conversation happening in a Chat Room.

Thank you for your consideration.

**EDIT**: Disclosure: I work for StackStorm.