### PR TITLE
Updating Analog link and name

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ Comparison of NoSQL servers: http://kkovacs.eu/cassandra-vs-mongodb-vs-couchdb-v
 ## Statistics
 *Analytics software.*
 
-* [Analog](http://www.analog.cx/) - The most popular logfile analyser in the world.
+* [Analog C:Amie Edition](http://www.c-amie.co.uk/analog/) - The most popular logfile analyser in the world.
 * [GoAccess](http://goaccess.io/) - Open source real-time web log analyzer and interactive viewer that runs in a terminal.
 * [Piwik](http://piwik.org/) - Free and open source web analytics application.
 * [Webalizer](http://www.webalizer.org/) - Fast, free web server log file analysis program.


### PR DESCRIPTION
Official Analog website is down. The project has been taken by C:Amie to maintain it.