### PR TITLE
Fix sshuttle repo to current maintained fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ Comparison of NoSQL servers: http://kkovacs.eu/cassandra-vs-mongodb-vs-couchdb-v
 * [OpenVPN](https://community.openvpn.net) - Uses a custom security protocol that utilizes SSL/TLS for key exchange.
 * [Pritunl](http://pritunl.com/) - OpenVPN based solution. Easy to set up.
 * [SoftEther](https://www.softether.org/) - Multi-protocol software VPN with advanced features
-* [sshuttle](https://github.com/apenwarr/sshuttle) - Poor man's VPN.
+* [sshuttle](https://github.com/sshuttle/sshuttle) - Poor man's VPN.
 * [strongSwan](http://www.strongswan.org/) - Complete IPsec implementation for Linux.
 * [tinc](http://www.tinc-vpn.org/) - Distributed p2p VPN.
 


### PR DESCRIPTION
The initial repo hasn't been touched since 2012, this fork is the most current, functional and maintained one.