### PR TITLE
update analog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ Comparison of NoSQL servers: http://kkovacs.eu/cassandra-vs-mongodb-vs-couchdb-v
 ## Statistics
 *Analytics software.*
 
-* [Analog](http://www.analog.cx/) - The most popular logfile analyser in the world.
+* [Analog](http://www.web42.com/analog/) - The most popular logfile analyser in the world.
 * [GoAccess](http://goaccess.io/) - Open source real-time web log analyzer and interactive viewer that runs in a terminal.
 * [Piwik](http://piwik.org/) - Free and open source web analytics application.
 * [Webalizer](http://www.webalizer.org/) - Fast, free web server log file analysis program.


### PR DESCRIPTION
The original link is outdated. It's a domain parking page now. After googling, I found [this](http://www.web42.com/analog/) may be the right link.