### PR TITLE
Add eZ Server Monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ A curated list of amazingly awesome open source sysadmin resources inspired by [
 * [Centreon](http://www.centreon.com) - IT infrastructure and application monitoring for service performance.
 * [check_mk](http://mathias-kettner.com/check_mk.html) - Collection of extensions for Nagios.
 * [Dash](https://github.com/afaqurk/linux-dash) - A low-overhead monitoring web dashboard for a GNU/Linux machine.
+* [eZ ServerMonitor](http://www.ezservermonitor.com) - A lightweight and simple dashboard monitor for Linux, available in Web and Bash application.
 * [Icinga](https://www.icinga.org/) - Fork of Nagios.
 * [LibreNMS](https://github.com/librenms/librenms/) - fork of Observium.
 * [Monit](http://mmonit.com/monit/#home) - Small Open Source utility for managing and monitoring Unix systems.


### PR DESCRIPTION
eZ Server Monitor is a lightweight and simple dashboard monitor for Linux available in Web and Bash application.

In its Web version, eZ Server Monitor is a PHP script which provides a web page containing information such as the operating system, the number of users connected to the server, the system load, CPU, memory RAM, available disk space, bandwidth usage, and especially the port monitoring services such as FTP, SMTP, Web, etc ...

eZ Server Monitor`sh is a Bash script displays on your console information such as the operating system, system load, CPU, RAM, disk space available, network information, temperatures, etc ...

Official Website : http://www.ezservermonitor.com
GitHub for eSM Web : https://github.com/shevabam/ezservermonitor-web
GitHub for eSM sh : https://github.com/shevabam/ezservermonitor-sh

Under *Monitoring* category.