### PR TITLE
replace attic with borgbackup

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ Please read [CONTRIBUTING](./CONTRIBUTING.md) if you wish to add software.
 *Backup software.*
 
 * [Amanda](http://www.amanda.org/) - Client-server model backup tool.
-* [Attic](https://attic-backup.org) - A deduplicating backup program written in Python.
 * [Bacula](http://www.bacula.org) - Another Client-server model backup tool.
 * [Bareos](http://www.bareos.org) - A fork of Bacula backup tool.
 * [Backupninja](https://labs.riseup.net/code/projects/backupninja) - Lightweight, extensible meta-backup system.
 * [Backuppc](http://backuppc.sourceforge.net/) - Client-server model backup tool with file pooling scheme.
+* [BorgBackup](https://borgbackup.readthedocs.io/) - Deduplicating backup program with compression and authenticated encryption.
 * [Brebis](http://brebisproject.org) - A fully automated backup checker.
 * [Bup](https://github.com/bup/bup) - Incremental backups with rolling checksums, git packfiles, de-duplication, and a FUSE filesystem.
 * [Burp](http://burp.grke.org/) - Network backup and restore program.


### PR DESCRIPTION
I am the guy who forked attic and created a community project called borgbackup from attic's codebase.

I thought attic is awesome and deserved faster development, more bug fixes and some more features. Sadly, that wasn't possible within the attic project, due to lack of time of original author and also different goals, thus the fork happened.

Usually, I would not remove other authors' projects from an awesome list, but I make an exception here as I know multiple severe attic bugs and limitations (which are all not fixed in attic as of now) like:

- backup repository corruption
- security issues
- scalability issues

I know these issues because we fixed them in borgbackup. These issues also lead to removal of attic from Debian.

So, for the sake of good, secure and better scalable backups, let's remove attic and add BorgBackup.

BorgBackup can be used instead of attic, we have a "borg upgrade" command that can "import" attic backup repositories.