### PR TITLE
Add Azkaban in Cloud Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Please read [CONTRIBUTING](./CONTRIBUTING.md) if you wish to add software.
 
 * [BOSH](http://docs.cloudfoundry.org/bosh/) -  IaaS orchestration platform originally written for deploying and managing Cloud Foundry PaaS, but also useful for general purpose distributed systems.
 * [Ansible](http://www.ansible.com) - Contains modules for controlling many types of cloud resources.
+* [Azkaban](https://azkaban.github.io/) - Open-source batch workflow job scheduler.
 * [Cloudify](http://www.getcloudify.org/) -  Open source TOSCA-based cloud orchestration software platform written in Python and YAML.
 * [consul](http://www.consul.io/) - It is a tool for discovering and configuring services in your infrastructure.
 * [doozerd](https://github.com/ha/doozerd) - Doozer is a highly-available, completely consistent store for small amounts of extremely important data.


### PR DESCRIPTION
Name: Azkaban
Category: Cloud Orchestration
Link: https://azkaban.github.io/