### PR TITLE
Add SciTE to the editors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ Please read [CONTRIBUTING](./CONTRIBUTING.md) if you wish to add software.
 * [jotgit](https://github.com/jdleesmiller/jotgit) - Git-backed real-time collaborative code editing.
 * [Light Table](http://www.lighttable.com/) - The next generation code editor.
 * [Lime](http://limetext.org/) - Aims to provide an open source solution to Sublime Text
+* [SciTE](http://www.scintilla.org/SciTE.html) - A SCIntilla based Text Editor.
 * [TextMate](https://github.com/textmate/textmate/) - A graphical text editor for OS X.
 * [Vim](http://www.vim.org) - A highly configurable text editor built to enable efficient editing.
 


### PR DESCRIPTION
From the web page:

"SciTE is a SCIntilla based Text Editor. Originally built to demonstrate Scintilla, it has grown to be a generally useful editor with facilities for building and running programs. It is best used for jobs with simple configurations - I use it for building test and demonstration programs as well as SciTE and Scintilla, themselves.

SciTE is currently available for Intel Windows (XP or later) and Linux compatible operating systems with GTK+. It has been run on Windows 7 and on Fedora 25 and Ubuntu 16.04 with GTK+ 2.24."