### PR TITLE
Added Sheepdog distributed filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Please read [CONTRIBUTING](./CONTRIBUTING.md) if you wish to add software.
 * [MooseFS](http://www.moosefs.org/) - Fault tolerant, network distributed file system.
 * [MogileFS](http://mogilefs.org/) - Application level, network distributed file system.
 * [OpenAFS](http://www.openafs.org/) - Distributed network file system with read-only replicas and multi-OS support.
+* [Sheepdog](https://github.com/sheepdog/sheepdog/wiki) - Sheepdog is a distributed storage system for QEMU, iSCSI clients and RESTful services as well as a file system with sheepfs.
 * [TahoeLAFS](https://tahoe-lafs.org/trac/tahoe-lafs) - secure, decentralized, fault-tolerant, peer-to-peer distributed data store and distributed file system.
 * [XtreemFS](http://www.xtreemfs.org/) - XtreemFS is a fault-tolerant distributed file system for all storage needs.
 


### PR DESCRIPTION
Sheepdog is a stable GPL2 licenced distributed block storage and filesystem by the japanese Nippon Telegraph and Telephone Corporation. 
