### PR TITLE
Add xiringuito - SSH-based "VPN for poors"

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,6 +675,7 @@ Please read [CONTRIBUTING](./CONTRIBUTING.md) if you wish to add software.
 * [strongSwan](http://www.strongswan.org/) - Complete IPsec implementation for Linux.
 * [tinc](http://www.tinc-vpn.org/) - Distributed p2p VPN.
 * [wireguard](https://www.wireguard.com/) - New minimal VPN Solution that is very fast.
+* [xiringuito](https://github.com/ivanilves/xiringuito) - SSH-based "VPN for poors".
 
 ## Web
 


### PR DESCRIPTION
Add xiringuito - SSH-based "VPN for poors"

### why it is awesome
`xiringuito` is awesome, because:
* easy to install (no dependencies, no configurations)
* allows you to manage one, few or many connections easily (and connect em simultaneously if you want)
* it has `xaval` connection manager - a tool that may record and later re-use your connection profiles
* though you are free to use or not to use `xaval` connection manager - people also use `xiringuito` for ad-hoc onetime connections
* Just look at this GIF :wink: 
![](https://github.com/ivanilves/xiringuito/raw/master/images/install.gif)