### PR TITLE
add AE-DIR and web2ldap

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ Please read [CONTRIBUTING](./CONTRIBUTING.md) if you wish to add software.
 *LDAP management*
 
 * [Apache Directory Studio](https://directory.apache.org/studio/) - The Eclipse-based LDAP browser and directory client
+* [web2ldap](https://www.web2ldap.de) - Full-featured LDAP client running as web application.
 
 ## Log Management
 

--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Please read [CONTRIBUTING](./CONTRIBUTING.md) if you wish to add software.
 *LDAP servers.*
 
 * [389 Directory Server](http://port389.org) - Developed by Red Hat.
+* [Æ-DIR](https://www.ae-dir.com/) - paranoid IAM based on OpenLDAP.
 * [Apache Directory Server](http://directory.apache.org/) - Apache Software Foundation project written in Java.
 * [Fusion Directory](http://www.fusiondirectory.org) - Improve the Management of the services and the company directory based on OpenLDAP.
 * [OpenDJ](http://opendj.forgerock.org/) - Fork of OpenDS.


### PR DESCRIPTION
### Application name / category
[Æ-DIR](https://www.ae-dir.com) / LDAP servers

### Source URL
https://gitlab.com/ae-dir

### why it is awesome
Being the author I'm biased.

### Application name / category
[web2ldap](https://www.web2ldap.de) / LDAP management

### Source URL
https://gitlab.com/ae-dir/web2ldap

### why it is awesome
Being the author I'm biased.
