### PR TITLE
add mailcow

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,8 +362,9 @@ Please read [CONTRIBUTING](./CONTRIBUTING.md) if you wish to add software.
 
 *Complete solutions.*
 
+* [mailcow](https://mailcow.email/) - mailcow: dockerized is based on Postfix, Dovecot, Nginx, PHP, MariaDB, Rspamd and more.
 * [Mail-in-a-Box](https://mailinabox.email/) - Take back control of your email with this easy-to-deploy mail server in a box.
-* [iRedMail](http://www.iredmail.org/) - Full-featured mail server solution based on Postfix and Dovecot.
+* [iRedMail](http://www.iredmail.org/) - Full-featured mail server solution based on Postfix and Dovecot. 
 
 ## Messaging
 


### PR DESCRIPTION
Add mailcow, a fullstack mailserver solution based on Postfix and Dovecot.