### PR TITLE
Add LanJournal to Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ Please read [CONTRIBUTING](./CONTRIBUTING.md) if you wish to add software.
 * [check_mk](http://mathias-kettner.com/check_mk.html) - Collection of extensions for Nagios.
 * [Flapjack](http://flapjack.io/) - Monitoring notification routing & event processing system.
 * [Icinga](https://www.icinga.org/) - Fork of Nagios.
-* [LanJournal](https://github.com/sertaccanbey/LanJournal) - Agentless network surveillance tool with a live dashboard.
+* [LanJournal](https://github.com/sertacanbey/LanJournal) - Agentless network surveillance tool with a live dashboard.
 * [LibreNMS](https://github.com/librenms/librenms/) - fork of Observium.
 * [Monit](http://mmonit.com/monit/#home) - Small Open Source utility for managing and monitoring Unix systems.
 * [Munin](http://munin-monitoring.org/) - Networked resource monitoring tool.

--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ Please read [CONTRIBUTING](./CONTRIBUTING.md) if you wish to add software.
 * [check_mk](http://mathias-kettner.com/check_mk.html) - Collection of extensions for Nagios.
 * [Flapjack](http://flapjack.io/) - Monitoring notification routing & event processing system.
 * [Icinga](https://www.icinga.org/) - Fork of Nagios.
+* [LanJournal](https://github.com/sertaccanbey/LanJournal) - Agentless network surveillance tool with a live dashboard.
 * [LibreNMS](https://github.com/librenms/librenms/) - fork of Observium.
 * [Monit](http://mmonit.com/monit/#home) - Small Open Source utility for managing and monitoring Unix systems.
 * [Munin](http://munin-monitoring.org/) - Networked resource monitoring tool.


### PR DESCRIPTION
Project Name: LanJournal
Category: Monitoring software
Link: https://github.com/sertaccanbey/LanJournal

Reason: LanJournal is a FLOSS (MIT Licensed), agentless network monitoring tool written in PowerShell. It features offline tracking and a lightweight HTML dashboard.