### PR TITLE
Add ReleaseRun HTTP Security Headers Analyzer to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@ Please read [CONTRIBUTING](./CONTRIBUTING.md) if you wish to add software.
 * [OSSEC](http://ossec.net) - OSSEC is a HIDS that performs log analysis, FIM, rootkit detection, and much more.
 * [OSQuery](https://osquery.io/) - Query your servers status and info using a SQL like interface.
 * [pfSense](https://www.pfsense.org/) - Firewall and Router FreeBSD distribution.
+* [ReleaseRun HTTP Security Headers Analyzer](https://releaserun.com/tools/security-headers/) - Paste HTTP response headers for an instant A-F security grade. Checks HSTS, CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy and more. Generates Nginx config snippets for missing headers.
 * [Snort](https://www.snort.org/) - Snort is a free and open source network intrusion prevention system (NIPS) and network intrusion detection system (NIDS) created by Martin Roesch in 1998.
 * [SpamAssassin](https://spamassassin.apache.org/) - A powerful and popular email spam filter employing a variety of detection technique.
 * [BounCA](https://bounca.org/) - BounCA is a personal SSL / Certificate Authority Key management tool. Create self-signed SSL certificates via your browser. ([Source Code](https://github.com/repleo/bounca)) `Apache` `Python`


### PR DESCRIPTION
## What this PR adds

Adds **[ReleaseRun HTTP Security Headers Analyzer](https://releaserun.com/tools/security-headers/)** to the Security section.

**What it does:** Free browser tool — paste your HTTP response headers (from `curl -I https://your-site.com` or browser DevTools) and get an instant A-F security grade.

**Checks 10 security headers:**
- `Strict-Transport-Security` (HSTS) — max-age, includeSubDomains
- `Content-Security-Policy` — presence of unsafe-inline/eval, wildcard sources
- `X-Frame-Options` — DENY/SAMEORIGIN clickjacking protection
- `X-Content-Type-Options` — nosniff
- `Referrer-Policy` — strict-origin-when-cross-origin
- `Permissions-Policy` — camera, microphone, geolocation
- `X-XSS-Protection` — legacy filter handling
- `Cache-Control` — no-store for sensitive pages
- `Server` / `X-Powered-By` — info leakage detection

**Outputs:** A-F grade (100pts), per-header PASS/WARN/FAIL with explanation, and a Nginx config snippet for any missing headers.

Free, client-side only, no signup required.